### PR TITLE
動画のサムネイルの表示方法を修正

### DIFF
--- a/app/qml/parts/VideoFrame.qml
+++ b/app/qml/parts/VideoFrame.qml
@@ -10,8 +10,8 @@ import "../compat"
 
 ClickableFrame {
     id: videoFrame
-    contentWidth: thumbImage.paintedWidth
-    contentHeight: thumbImage.paintedHeight
+    contentWidth: thumbImage.width
+    contentHeight: thumbImage.height
 
     topInset: 0
     leftInset: 0
@@ -22,12 +22,27 @@ ClickableFrame {
     rightPadding: 0
     bottomPadding: 0
 
-    property alias thumbImage: thumbImage
+    property string thumbImageSource: ""
+    onThumbImageSourceChanged: {
+        if(thumbImage.status != Image.Ready){
+            thumbImage.source = thumbImageSource
+        }
+    }
 
     ImageWithIndicator {
         id: thumbImage
         width: videoFrame.width
-        height: status !== Image.Null ? (width / sourceSize.width) * sourceSize.height : 5
+        height: {
+            if(status !== Image.Null) {
+                if(sourceSize.width > sourceSize.height){
+                    return (width / sourceSize.width) * sourceSize.height
+                }else{
+                    return width * 9 / 16
+                }
+            }else{
+                return 0
+            }
+        }
         fillMode: Image.PreserveAspectCrop
 
         Image {

--- a/app/qml/view/NotificationListView.qml
+++ b/app/qml/view/NotificationListView.qml
@@ -128,11 +128,11 @@ ScrollView {
             quoteRecordImagePreview.embedAlts: model.quoteRecordEmbedImagesAlt
             quoteRecordImagePreview.onRequestViewImages: (index) => requestViewImages(index, model.quoteRecordEmbedImagesFull, model.quoteRecordEmbedImagesAlt)
             quoteRecordEmbedVideoFrame.visible: model.quoteRecordHasVideo
-            quoteRecordEmbedVideoFrame.thumbImage.source: model.quoteRecordVideoThumb
+            quoteRecordEmbedVideoFrame.thumbImageSource: model.quoteRecordVideoThumb
             quoteRecordEmbedVideoFrame.onClicked: Qt.openUrlExternally(rootListView.model.getItemOfficialUrl(model.index))
             embedVideoFrame.visible: model.hasVideo
             embedVideoFrame.onClicked: Qt.openUrlExternally(rootListView.model.getItemOfficialUrl(model.index))
-            embedVideoFrame.thumbImage.source: model.videoThumbUri
+            embedVideoFrame.thumbImageSource: model.videoThumbUri
 
             externalLinkFrame.visible: model.hasExternalLink && contentMediaFilterFrame.showContent
             externalLinkFrame.onClicked: Qt.openUrlExternally(model.externalLinkUri)

--- a/app/qml/view/PostThreadView.qml
+++ b/app/qml/view/PostThreadView.qml
@@ -166,11 +166,11 @@ ColumnLayout {
                 quoteRecordImagePreview.embedAlts: model.quoteRecordEmbedImagesAlt
                 quoteRecordImagePreview.onRequestViewImages: (index) => requestViewImages(index, model.quoteRecordEmbedImagesFull, model.quoteRecordEmbedImagesAlt)
                 quoteRecordFrame.quoteRecordEmbedVideoFrame.visible: model.quoteRecordHasVideo
-                quoteRecordFrame.quoteRecordEmbedVideoFrame.thumbImage.source: model.quoteRecordVideoThumb
+                quoteRecordFrame.quoteRecordEmbedVideoFrame.thumbImageSource: model.quoteRecordVideoThumb
                 quoteRecordFrame.quoteRecordEmbedVideoFrame.onClicked: Qt.openUrlExternally(rootListView.model.getItemOfficialUrl(model.index))
                 embedVideoFrame.visible: model.hasVideo
                 embedVideoFrame.onClicked: Qt.openUrlExternally(rootListView.model.getItemOfficialUrl(model.index))
-                embedVideoFrame.thumbImage.source: model.videoThumbUri
+                embedVideoFrame.thumbImageSource: model.videoThumbUri
 
                 externalLinkFrame.visible: model.hasExternalLink && contentMediaFilterFrame.showContent
                 externalLinkFrame.onClicked: Qt.openUrlExternally(model.externalLinkUri)

--- a/app/qml/view/TimelineView.qml
+++ b/app/qml/view/TimelineView.qml
@@ -163,11 +163,11 @@ ScrollView {
             quoteRecordImagePreview.embedAlts: model.quoteRecordEmbedImagesAlt
             quoteRecordImagePreview.onRequestViewImages: (index) => requestViewImages(index, model.quoteRecordEmbedImagesFull, model.quoteRecordEmbedImagesAlt)
             quoteRecordFrame.quoteRecordEmbedVideoFrame.visible: model.quoteRecordHasVideo
-            quoteRecordFrame.quoteRecordEmbedVideoFrame.thumbImage.source: model.quoteRecordVideoThumb
+            quoteRecordFrame.quoteRecordEmbedVideoFrame.thumbImageSource: model.quoteRecordVideoThumb
             quoteRecordFrame.quoteRecordEmbedVideoFrame.onClicked: Qt.openUrlExternally(rootListView.model.getItemOfficialUrl(model.index))
             embedVideoFrame.visible: model.hasVideo
             embedVideoFrame.onClicked: Qt.openUrlExternally(rootListView.model.getItemOfficialUrl(model.index))
-            embedVideoFrame.thumbImage.source: model.videoThumbUri
+            embedVideoFrame.thumbImageSource: model.videoThumbUri
 
             externalLinkFrame.visible: model.hasExternalLink && contentMediaFilterFrame.showContent
             externalLinkFrame.onClicked: Qt.openUrlExternally(model.externalLinkUri)

--- a/app/qtquick/timeline/timelinelistmodel.cpp
+++ b/app/qtquick/timeline/timelinelistmodel.cpp
@@ -1124,12 +1124,14 @@ QVariant TimelineListModel::getQuoteItem(const AtProtocolType::AppBskyFeedDefs::
         if (has_record
             && !post.embed_AppBskyEmbedRecord_View->record_ViewRecord.embeds_AppBskyEmbedVideo_View
                         .isEmpty()) {
-            return post.embed_AppBskyEmbedRecord_View->record_ViewRecord
-                    .embeds_AppBskyEmbedVideo_View.first()
-                    .thumbnail;
+            return AtProtocolType::LexiconsTypeUnknown::convertVideoThumb(
+                    post.embed_AppBskyEmbedRecord_View->record_ViewRecord
+                            .embeds_AppBskyEmbedVideo_View.first()
+                            .thumbnail);
         } else if (has_with_image) {
-            return post.embed_AppBskyEmbedRecordWithMedia_View.media_AppBskyEmbedVideo_View
-                    .thumbnail;
+            return AtProtocolType::LexiconsTypeUnknown::convertVideoThumb(
+                    post.embed_AppBskyEmbedRecordWithMedia_View.media_AppBskyEmbedVideo_View
+                            .thumbnail);
         } else {
             return QString();
         }

--- a/lib/atprotocol/lexicons_func_unknown.cpp
+++ b/lib/atprotocol/lexicons_func_unknown.cpp
@@ -131,7 +131,7 @@ QString copyVideoFromPostView(const AppBskyFeedDefs::PostView &post, const CopyI
     if (post.embed_type == AppBskyFeedDefs::PostViewEmbedType::embed_AppBskyEmbedVideo_View) {
         switch (type) {
         case AtProtocolType::LexiconsTypeUnknown::CopyImageType::Thumb:
-            return post.embed_AppBskyEmbedVideo_View.thumbnail;
+            return convertVideoThumb(post.embed_AppBskyEmbedVideo_View.thumbnail);
         case AtProtocolType::LexiconsTypeUnknown::CopyImageType::Alt:
             return post.embed_AppBskyEmbedVideo_View.alt;
         case AtProtocolType::LexiconsTypeUnknown::CopyImageType::FullSize:
@@ -436,6 +436,23 @@ QString applyFacetsTo(const QString &text, const QList<AppBskyRichtextFacet::Mai
 
         return text;
     }
+}
+
+QString convertVideoThumb(const QString &url)
+{
+#if 0
+    if (url.startsWith("https://video.bsky.app/watch/")) {
+        QStringList items = url.split("/");
+        if (items.length() == 7 && items.last() == "thumbnail.jpg" && items.at(4).startsWith("did")
+            && items.at(4).contains("%3A")) {
+            QString t = items.at(4);
+            t.replace("%3A", ":");
+            return QString("https://video.cdn.bsky.app/hls/%1/%2/thumbnail.jpg")
+                    .arg(t, items.at(5));
+        }
+    }
+#endif
+    return url;
 }
 }
 }

--- a/lib/atprotocol/lexicons_func_unknown.h
+++ b/lib/atprotocol/lexicons_func_unknown.h
@@ -65,6 +65,8 @@ bool checkPartialMatchLanguage(const QStringList &langs);
 QString copyRecordText(const QVariant &value);
 QString formatDateTime(const QString &value, const bool is_long = false);
 
+QString convertVideoThumb(const QString &url);
+
 void makeFacets(QObject *parent, AtProtocolInterface::AccountData account, const QString &text,
                 std::function<void(const QList<AtProtocolType::AppBskyRichtextFacet::Main> &facets)>
                         callback);

--- a/tests/atprotocol_test/tst_atprotocol_test.cpp
+++ b/tests/atprotocol_test/tst_atprotocol_test.cpp
@@ -84,6 +84,8 @@ private slots:
     void test_DirectoryPlcLogAudit();
     void test_PinnedPostCache();
 
+    void test_convertVideoThumb();
+
 private:
     void test_putPreferences(const QString &path, const QByteArray &body);
     void test_putRecord(const QString &path, const QByteArray &body);
@@ -2370,6 +2372,22 @@ void atprotocol_test::test_PinnedPostCache()
     //
     PinnedPostCache::getInstance()->update("did2", "");
     QVERIFY(PinnedPostCache::getInstance()->pinned("did2", "") == false);
+}
+
+void atprotocol_test::test_convertVideoThumb()
+{
+
+    QString url;
+
+    url = AtProtocolType::LexiconsTypeUnknown::convertVideoThumb(
+            "https://video.bsky.app/watch/did%3Aplc%3Aipj5qejfoqu6eukvt72uhyit/"
+            "bafkreie2dwcpkwtx4jqjh4qwcvgf3zs4eis3gt6wjgtd2smrheh5m3s62i/thumbnail.jpg");
+#if 0
+    QVERIFY2(url
+                     == "https://video.cdn.bsky.app/hls/did:plc:ipj5qejfoqu6eukvt72uhyit/"
+                        "bafkreie2dwcpkwtx4jqjh4qwcvgf3zs4eis3gt6wjgtd2smrheh5m3s62i/thumbnail.jpg",
+             url.toLocal8Bit());
+#endif
 }
 
 void atprotocol_test::test_putPreferences(const QString &path, const QByteArray &body)


### PR DESCRIPTION
VideoFrameの変更
動画のサムネはリダイレクトされるので再読み込みするたびにリダイレクト前のURLに戻して再読み込みが発生してしまうので、1度設定したら変更しないようにイベントをとおして設定する