### PR TITLE
ユニバーサルバイナリを作成する機能を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,9 @@ openssl/private
 openssl/share
 openssl/*.cnf
 openssl/*.cnf.dist
+openssl/lib.lipo
+openssl_x86_64/
+openssl_arm64/
 zlib/bin
 zlib/include
 zlib/lib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,6 @@ project(HagoromoProject LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-if(APPLE)
-    set(CMAKE_OSX_ARCHITECTURES "x86_64")
-endif()
 
 add_subdirectory(lib)
 add_subdirectory(app)


### PR DESCRIPTION
OpenSSLのビルドスクリプトを更新し、macOS向けにユニバーサルバイナリを作成する機能を追加
.gitignoreにOpenSSLの新しいディレクトリを追加
CMakeLists.txtからApple特有のアーキテクチャ設定を削除